### PR TITLE
Fixed Dockerfile issue with casing of FROM and AS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN go mod download
 COPY . .
 RUN go build -ldflags "-s -w" -o ./goapi-template ./main.go
 
-FROM scratch as runner
+FROM scratch AS runner
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /etc/group /etc/group


### PR DESCRIPTION
This pull request includes a minor change to the `Dockerfile` to standardize the casing of the `AS` keyword in a multi-stage build.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L24-R24): Updated the `FROM scratch as runner` line to use uppercase `AS` for consistency with Dockerfile best practices.